### PR TITLE
Fixed missing return in ResponseTransformer.

### DIFF
--- a/Controller/ResponseTransformer.php
+++ b/Controller/ResponseTransformer.php
@@ -53,7 +53,7 @@ class ResponseTransformer
     {
         $templatePath = $this->getTemplatePathFromController($event);
         if (is_null($templatePath)) {
-            new FulfilledPromise($event->getControllerResult());
+            return new FulfilledPromise($event->getControllerResult());
         }
 
         $controllerResult = $event->getControllerResult();

--- a/Tests/Controller/DtoController.php
+++ b/Tests/Controller/DtoController.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drift\Twig\Tests\Controller;
+
+/**
+ * Class NotATwigController
+ */
+class DtoController
+{
+    public function __invoke()
+    {
+        // just need anything I can run instanceof on...
+        return new self;
+    }
+}

--- a/Tests/TwigBundleFunctionalTest.php
+++ b/Tests/TwigBundleFunctionalTest.php
@@ -17,6 +17,7 @@ namespace Drift\Twig\Tests;
 
 use Drift\Twig\Tests\Controller\AController;
 use Drift\Twig\Tests\Controller\BController;
+use Drift\Twig\Tests\Controller\DtoController;
 use Drift\Twig\TwigBundle;
 use Mmoreram\BaseBundle\Kernel\DriftBaseKernel;
 use Mmoreram\BaseBundle\Tests\BaseFunctionalTest;
@@ -72,6 +73,11 @@ abstract class TwigBundleFunctionalTest extends BaseFunctionalTest
                 '/b',
                 BController::class,
                 'b',
+            ],
+            [
+                '/dto',
+                DtoController::class,
+                'dto',
             ],
         ], 'test', false);
     }


### PR DESCRIPTION
ResponseTransformer missed a return when no `$templatePath` was given, so ControllerResults not intended to be rendered by Twig, e.g. DTOs, where not supported, because it threw an TypeError when they wherepassed to `solvePromises(<here>,...)`.

